### PR TITLE
fix: back button uses navigate(-1) to preserve search state Closes #304

### DIFF
--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -194,7 +194,7 @@ export function ProductDetail({
       <div className="flex flex-wrap items-center gap-3 justify-between mb-4 sm:mb-6 sm:flex-nowrap">
         <Button
           variant="outline"
-          onClick={onBack}
+          onClick={() => navigate(-1)}
           className="-ml-2 flex items-center gap-1 sm:gap-2 px-2 sm:px-3"
           aria-label="Back to products"
         >


### PR DESCRIPTION
Changed onClick to go back one in memory, instead of back to home page.