### PR TITLE
Fix product title overflow overlapping discussion section

### DIFF
--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -399,7 +399,7 @@ export function ProductDetail({
       )}
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 sm:gap-8">
-        <div className="lg:col-span-2">
+        <div className="lg:col-span-2 min-w-0">
           <div className="mb-6">
             {shouldShowImage ? (
               <div className="float-left mr-4 mb-3 sm:mr-6 sm:mb-4 max-w-[300px] w-full">
@@ -427,10 +427,10 @@ export function ProductDetail({
             )}
 
             <div className="flex items-start justify-between gap-3 sm:gap-4 mb-2 sm:mb-3">
-              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight leading-tight line-clamp-2 sm:line-clamp-none">
+              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight leading-tight line-clamp-2 sm:line-clamp-none break-words min-w-0">
                 {product.name}
               </h1>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-2 shrink-0">
                 {product.banned && <Badge variant="destructive">Banned</Badge>}
               </div>
             </div>

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -421,8 +421,8 @@ export function ProductDetail({
                 )}
               </div>
             ) : (
-              <div className="float-left mr-4 mb-3 sm:mr-6 sm:mb-4 rounded-lg max-w-[300px] w-full h-auto min-h-[180px] bg-muted text-muted-foreground flex items-center justify-center text-sm">
-                <span>Image unavailable for {product.name}</span>
+              <div className="float-left mr-4 mb-3 sm:mr-6 sm:mb-4 rounded-lg max-w-[300px] w-full h-auto min-h-[180px] bg-muted text-muted-foreground flex items-center justify-center text-sm p-2">
+                <span className="min-w-0 break-words text-center">Image unavailable for {product.name}</span>
               </div>
             )}
 

--- a/src/components/ProductDetail.tsx
+++ b/src/components/ProductDetail.tsx
@@ -422,12 +422,12 @@ export function ProductDetail({
               </div>
             ) : (
               <div className="float-left mr-4 mb-3 sm:mr-6 sm:mb-4 rounded-lg max-w-[300px] w-full h-auto min-h-[180px] bg-muted text-muted-foreground flex items-center justify-center text-sm p-2">
-                <span className="min-w-0 break-words text-center">Image unavailable for {product.name}</span>
+                <span className="min-w-0 wrap-anywhere text-center">Image unavailable for {product.name}</span>
               </div>
             )}
 
             <div className="flex items-start justify-between gap-3 sm:gap-4 mb-2 sm:mb-3">
-              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight leading-tight line-clamp-2 sm:line-clamp-none break-words min-w-0">
+              <h1 className="text-2xl sm:text-3xl font-bold tracking-tight leading-tight line-clamp-2 sm:line-clamp-none wrap-anywhere min-w-0">
                 {product.name}
               </h1>
               <div className="flex items-center gap-2 shrink-0">


### PR DESCRIPTION
### What does this Pull Request do?

Fixes a layout bug where long, unbroken product titles (e.g. underscore-separated names like "Picarx_voice_keyboard_controlled_assistant") overflow their container and visually overlap the Discussion sidebar on the product detail page.

### Why?
Fixes issue #302. Long titles with no spaces are treated as a single unbreakable word by the browser, and without "min-w-0" on the grid/flex ancestors or an "overflow-wrap" rule on the title, it overflows its column and renders on top of the sidebar.

### How was it tested?
"eslint" passes clean on the changed file.
