### PR TITLE
Fix product cards overlapping in My Products view

### DIFF
--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -371,12 +371,12 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
                   }}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <div className="space-y-1 min-w-0">
-                      <h3 className="font-semibold leading-tight break-words">{product.name}</h3>
+                    <div className="space-y-1 min-w-0 flex-1">
+                      <h3 className="font-semibold leading-tight wrap-anywhere">{product.name}</h3>
                       {product.description && (
                         <MarkdownText
                           text={product.description}
-                          className="text-sm text-muted-foreground line-clamp-2"
+                          className="text-sm text-muted-foreground line-clamp-2 wrap-anywhere"
                         />
                       )}
                     </div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -380,7 +380,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
                         />
                       )}
                     </div>
-                    <div className="flex gap-1 flex-wrap justify-end shrink-0">
+                    <div className="flex gap-1 flex-wrap justify-end">
                       {product.type && (
                         <Badge variant="outline" className="text-xs capitalize">
                           {product.type}

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -371,8 +371,8 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
                   }}
                 >
                   <div className="flex items-start justify-between gap-2">
-                    <div className="space-y-1">
-                      <h3 className="font-semibold leading-tight">{product.name}</h3>
+                    <div className="space-y-1 min-w-0">
+                      <h3 className="font-semibold leading-tight break-words">{product.name}</h3>
                       {product.description && (
                         <MarkdownText
                           text={product.description}
@@ -380,7 +380,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
                         />
                       )}
                     </div>
-                    <div className="flex gap-1 flex-wrap justify-end">
+                    <div className="flex gap-1 flex-wrap justify-end shrink-0">
                       {product.type && (
                         <Badge variant="outline" className="text-xs capitalize">
                           {product.type}


### PR DESCRIPTION
**What does this PR do?**
Fixes overlapping badges (e.g. "Tool", "Archive.Org") on product cards in the "My Products" section of the profile page.

**Why?**
Closes #500. Without min-w-0 on the title/description block, an unbreakable long title could push the row past the card's boundary which spills badges onto the next card. 
