### PR TITLE
Part 2:  Fix Typescript errors (issue #508)

### DIFF
--- a/src/__tests__/accessibility/ProductSubmission.a11y.test.tsx
+++ b/src/__tests__/accessibility/ProductSubmission.a11y.test.tsx
@@ -23,8 +23,8 @@ describe('ProductSubmission Accessibility Tests', () => {
   beforeEach(async () => {
     // Set auth token getter for dev mode
     APIService.setAuthTokenGetter(async () => getDevToken(DEV_USERS.user.role))
-    vi.spyOn(APIService, 'productExistsByUrl').mockResolvedValue({ exists: false, product: null })
-    vi.spyOn(APIService, 'loadUrl').mockResolvedValue({ success: false, source: 'scraper', product: null })
+    vi.spyOn(APIService, 'productExistsByUrl').mockResolvedValue({ exists: false, product: undefined })
+    vi.spyOn(APIService, 'loadUrl').mockResolvedValue({ success: false, source: 'scraper', product: undefined })
     vi.clearAllMocks()
   })
 

--- a/src/__tests__/accessibility/ProfileEdit.a11y.test.tsx
+++ b/src/__tests__/accessibility/ProfileEdit.a11y.test.tsx
@@ -215,7 +215,7 @@ describeWithBackend('ProfileEdit Accessibility Tests (Story 1.3)', () => {
       )
 
       // Username should be visible but not as an editable input in the main view
-      expect(screen.getByText(testAccount.username)).toBeInTheDocument()
+      expect(screen.getByText(testAccount.username!)).toBeInTheDocument()
     })
   })
 

--- a/src/components/AboutPage.tsx
+++ b/src/components/AboutPage.tsx
@@ -18,7 +18,7 @@ export function AboutPage() {
           throw new Error(`Failed to load about content (status ${response.status})`)
         }
         const markdown = await response.text()
-        const html = marked.parse(markdown)
+        const html = await marked.parse(markdown)
         const safeHtml = DOMPurify.sanitize(html)
         setContent(safeHtml)
       } catch (err) {

--- a/src/components/PublicProfile.tsx
+++ b/src/components/PublicProfile.tsx
@@ -41,7 +41,17 @@ export function PublicProfile({ username }: { username: string }) {
           const effectiveUsername = acct.username ?? username
           const statsUserRef = acct.id || effectiveUsername
           const s = await APIService.getUserStats(statsUserRef)
-          setStats(s)
+          setStats({
+            productsSubmitted: s.productsSubmitted ?? 0,
+            collectionsCreated: s.collectionsCreated ?? 0,
+            productsOwnedSubmitted: s.productsOwnedSubmitted ?? 0,
+            productsEditedManaged: s.productsEditedManaged ?? 0,
+            collectionsOwnedSubmitted: s.collectionsOwnedSubmitted ?? 0,
+            collectionsEditedManaged: s.collectionsEditedManaged ?? 0,
+            ratingsGiven: s.ratingsGiven ?? 0,
+            discussionsParticipated: s.discussionsParticipated ?? 0,
+            totalContributions: s.totalContributions ?? 0,
+          })
 
           // Load products the user can edit (owner or editor) from the
           // relationship-backed endpoint.

--- a/src/components/PublicProfile.tsx
+++ b/src/components/PublicProfile.tsx
@@ -6,20 +6,11 @@ import { Badge } from '@/components/ui/badge'
 import { CalendarBlank, Globe, MapPin, ChartBar, BookOpen, Article } from '@phosphor-icons/react'
 import { APIService } from '@/lib/api'
 import { UserAccount, Product, Collection, BlogPost } from '@/lib/types'
+import { EMPTY_USER_STATS, fetchUserStats } from '@/lib/userStats'
 
 export function PublicProfile({ username }: { username: string }) {
   const [account, setAccount] = useState<UserAccount | null>(null)
-  const [stats, setStats] = useState({
-    productsSubmitted: 0,
-    collectionsCreated: 0,
-    productsOwnedSubmitted: 0,
-    productsEditedManaged: 0,
-    collectionsOwnedSubmitted: 0,
-    collectionsEditedManaged: 0,
-    ratingsGiven: 0,
-    discussionsParticipated: 0,
-    totalContributions: 0,
-  })
+  const [stats, setStats] = useState(EMPTY_USER_STATS)
   const [managedProducts, setManagedProducts] = useState<Product[]>([])
   const [userCollections, setUserCollections] = useState<Collection[]>([])
   const [blogPosts, setBlogPosts] = useState<BlogPost[]>([])
@@ -40,18 +31,8 @@ export function PublicProfile({ username }: { username: string }) {
           setAccount(acct)
           const effectiveUsername = acct.username ?? username
           const statsUserRef = acct.id || effectiveUsername
-          const s = await APIService.getUserStats(statsUserRef)
-          setStats({
-            productsSubmitted: s.productsSubmitted ?? 0,
-            collectionsCreated: s.collectionsCreated ?? 0,
-            productsOwnedSubmitted: s.productsOwnedSubmitted ?? 0,
-            productsEditedManaged: s.productsEditedManaged ?? 0,
-            collectionsOwnedSubmitted: s.collectionsOwnedSubmitted ?? 0,
-            collectionsEditedManaged: s.collectionsEditedManaged ?? 0,
-            ratingsGiven: s.ratingsGiven ?? 0,
-            discussionsParticipated: s.discussionsParticipated ?? 0,
-            totalContributions: s.totalContributions ?? 0,
-          })
+          const s = await fetchUserStats(statsUserRef)
+          setStats(s)
 
           // Load products the user can edit (owner or editor) from the
           // relationship-backed endpoint.

--- a/src/components/RavelrySettings.tsx
+++ b/src/components/RavelrySettings.tsx
@@ -25,6 +25,7 @@ type SaveLog = {
   message?: string
   status?: number
   error?: string
+  data?: unknown
 }
 
 type RavelrySettingsProps = {
@@ -537,7 +538,7 @@ export function RavelrySettings({ onAuthComplete, products: _products = [], onPr
                 <div className="space-y-1">
                   <p className="text-xs font-medium">Timestamp:</p>
                   <code className="block text-xs bg-(--color-bg) p-2 rounded">
-                    {new Date(oauthFlowLog.timestamp).toLocaleString()}
+                    {oauthFlowLog.timestamp ? new Date(oauthFlowLog.timestamp).toLocaleString() : 'Unknown time'}
                   </code>
                 </div>
                 {oauthFlowLog.authUrl && (

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -55,7 +55,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
   useEffect(() => {
     const loadStats = async () => {
       const userStats = await fetchUserStats(userAccount.id || userAccount.username || '')
-      setStats()
+      setStats(userStats)
     }
     loadStats()
   }, [userAccount.id, userAccount.username])

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -144,7 +144,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
             <div className="flex items-start gap-4">
               <Avatar className="w-20 h-20">
                 <AvatarImage src={userAccount.avatarUrl} alt={userAccount.username} />
-                <AvatarFallback>{(userAccount.username ?? '[missing]').slice(0, 2).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>{(userAccount.username || '?').slice(0, 2).toUpperCase()}</AvatarFallback>
               </Avatar>
               <div className="space-y-2">
                 <div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -63,8 +63,18 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
 
   useEffect(() => {
     const loadStats = async () => {
-      const userStats = await APIService.getUserStats(userAccount.id || userAccount.username)
-      setStats(userStats)
+      const userStats = await APIService.getUserStats(userAccount.id || userAccount.username || '')
+      setStats({
+        productsSubmitted: userStats.productsSubmitted ?? 0,
+        collectionsCreated: userStats.collectionsCreated ?? 0,
+        productsOwnedSubmitted: userStats.productsOwnedSubmitted ?? 0,
+        productsEditedManaged: userStats.productsEditedManaged ?? 0,
+        collectionsOwnedSubmitted: userStats.collectionsOwnedSubmitted ?? 0,
+        collectionsEditedManaged: userStats.collectionsEditedManaged ?? 0,
+        ratingsGiven: userStats.ratingsGiven ?? 0,
+        discussionsParticipated: userStats.discussionsParticipated ?? 0,
+        totalContributions: userStats.totalContributions ?? 0,
+      })
     }
     loadStats()
   }, [userAccount.id, userAccount.username])
@@ -153,7 +163,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
             <div className="flex items-start gap-4">
               <Avatar className="w-20 h-20">
                 <AvatarImage src={userAccount.avatarUrl} alt={userAccount.username} />
-                <AvatarFallback>{userAccount.username.slice(0, 2).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>{(userAccount.username ?? '').slice(0, 2).toUpperCase()}</AvatarFallback>
               </Avatar>
               <div className="space-y-2">
                 <div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -163,7 +163,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
             <div className="flex items-start gap-4">
               <Avatar className="w-20 h-20">
                 <AvatarImage src={userAccount.avatarUrl} alt={userAccount.username} />
-                <AvatarFallback>{(userAccount.username ?? '').slice(0, 2).toUpperCase()}</AvatarFallback>
+                <AvatarFallback>{(userAccount.username ?? '[missing]').slice(0, 2).toUpperCase()}</AvatarFallback>
               </Avatar>
               <div className="space-y-2">
                 <div>

--- a/src/components/UserProfile.tsx
+++ b/src/components/UserProfile.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/components/ui/dialog'
 import { UserAccount, UserData, Product, BlogPost } from '@/lib/types'
 import { APIService } from '@/lib/api'
+import { EMPTY_USER_STATS, fetchUserStats } from '@/lib/userStats'
 import { UserRequestsPanel } from '@/components/UserRequestsPanel'
 import { Pencil, MapPin, Globe, CalendarBlank, ChartBar, Package, Article, CaretDown, CaretRight } from '@phosphor-icons/react'
 import { useNotifications } from '@/contexts/NotificationContext'
@@ -44,17 +45,7 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
   const [bio, setBio] = useState(userAccount.bio || '')
   const [location, setLocation] = useState(userAccount.location || '')
   const [website, setWebsite] = useState(userAccount.website || '')
-  const [stats, setStats] = useState({
-    productsSubmitted: 0,
-    collectionsCreated: 0,
-    productsOwnedSubmitted: 0,
-    productsEditedManaged: 0,
-    collectionsOwnedSubmitted: 0,
-    collectionsEditedManaged: 0,
-    ratingsGiven: 0,
-    discussionsParticipated: 0,
-    totalContributions: 0,
-  })
+  const [stats, setStats] = useState(EMPTY_USER_STATS)
   const [ownedProducts, setOwnedProducts] = useState<Product[]>([])
   const [loadingOwnedProducts, setLoadingOwnedProducts] = useState(false)
   const [ownedProductsError, setOwnedProductsError] = useState<string | null>(null)
@@ -63,18 +54,8 @@ export function UserProfile({ userAccount, user, onUpdate, onProductClick, onCol
 
   useEffect(() => {
     const loadStats = async () => {
-      const userStats = await APIService.getUserStats(userAccount.id || userAccount.username || '')
-      setStats({
-        productsSubmitted: userStats.productsSubmitted ?? 0,
-        collectionsCreated: userStats.collectionsCreated ?? 0,
-        productsOwnedSubmitted: userStats.productsOwnedSubmitted ?? 0,
-        productsEditedManaged: userStats.productsEditedManaged ?? 0,
-        collectionsOwnedSubmitted: userStats.collectionsOwnedSubmitted ?? 0,
-        collectionsEditedManaged: userStats.collectionsEditedManaged ?? 0,
-        ratingsGiven: userStats.ratingsGiven ?? 0,
-        discussionsParticipated: userStats.discussionsParticipated ?? 0,
-        totalContributions: userStats.totalContributions ?? 0,
-      })
+      const userStats = await fetchUserStats(userAccount.id || userAccount.username || '')
+      setStats()
     }
     loadStats()
   }, [userAccount.id, userAccount.username])

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps } from "react"
 import * as AccordionPrimitive from "@radix-ui/react-accordion"
-import ChevronDownIcon from "lucide-react/dist/esm/icons/chevron-down"
+import { ChevronDownIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,7 +1,6 @@
 import { ComponentProps } from "react"
 import { Slot } from "@radix-ui/react-slot"
-import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
-import MoreHorizontal from "lucide-react/dist/esm/icons/more-horizontal"
+import { ChevronRight, MoreHorizontal } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -1,6 +1,5 @@
 import { ComponentProps } from "react"
-import ChevronLeft from "lucide-react/dist/esm/icons/chevron-left"
-import ChevronRight from "lucide-react/dist/esm/icons/chevron-right"
+import { ChevronLeft, ChevronRight } from "lucide-react"
 import { DayPicker } from "react-day-picker"
 
 import { cn } from "@/lib/utils"
@@ -60,10 +59,30 @@ function Calendar({
       }}
       components={{
         PreviousMonthButton: ({ className, ...props }) => (
-          <ChevronLeft className={cn("size-4", className)} {...props} />
+          <button
+            type="button"
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+              className
+            )}
+            {...props}
+          >
+            <ChevronLeft className="size-4" />
+          </button>
         ),
         NextMonthButton: ({ className, ...props }) => (
-          <ChevronRight className={cn("size-4", className)} {...props} />
+          <button
+            type="button"
+            className={cn(
+              buttonVariants({ variant: "outline" }),
+              "size-7 bg-transparent p-0 opacity-50 hover:opacity-100",
+              className
+            )}
+            {...props}
+          >
+            <ChevronRight className="size-4" />
+          </button>
         ),
       }}
       {...props}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -4,8 +4,7 @@ import { ComponentProps, createContext, useCallback, useContext, useEffect, useS
 import useEmblaCarousel, {
   type UseEmblaCarouselType,
 } from "embla-carousel-react"
-import ArrowLeft from "lucide-react/dist/esm/icons/arrow-left"
-import ArrowRight from "lucide-react/dist/esm/icons/arrow-right"
+import { ArrowLeft, ArrowRight } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button } from "@/components/ui/button"

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -1,7 +1,14 @@
 import { ComponentProps, ComponentType, createContext, CSSProperties, ReactNode, useContext, useId, useMemo } from "react"
 import * as RechartsPrimitive from "recharts"
+import type { TooltipContentProps, TooltipPayloadEntry } from "recharts"
 
 import { cn } from "@/lib/utils"
+
+// recharts 3.7.0 doesn't re-export ValueType/NameType from the package root,
+// so declare matching aliases locally (shape copied from
+// node_modules/recharts/types/component/DefaultTooltipContent.d.ts).
+type ValueType = number | string | ReadonlyArray<number | string>
+type NameType = number | string
 
 // Format: { THEME_NAME: CSS_SELECTOR }
 const THEMES = { light: "", dark: ".dark" } as const
@@ -116,7 +123,7 @@ function ChartTooltipContent({
   color,
   nameKey,
   labelKey,
-}: ComponentProps<typeof RechartsPrimitive.Tooltip> &
+}: TooltipContentProps<ValueType, NameType> &
   ComponentProps<"div"> & {
     hideLabel?: boolean
     hideIndicator?: boolean
@@ -180,11 +187,11 @@ function ChartTooltipContent({
         {payload.map((item, index) => {
           const key = `${nameKey || item.name || item.dataKey || "value"}`
           const itemConfig = getPayloadConfigFromPayload(config, item, key)
-          const indicatorColor = color || item.payload.fill || item.color
+          const indicatorColor = color || (item.payload as any)?.fill || item.color
 
           return (
             <div
-              key={item.dataKey}
+              key={item.dataKey?.toString() ?? index}
               className={cn(
                 "[&>svg]:text-muted-foreground flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5",
                 indicator === "dot" && "items-center"
@@ -230,9 +237,11 @@ function ChartTooltipContent({
                         {itemConfig?.label || item.name}
                       </span>
                     </div>
-                    {item.value && (
+                    {item.value !== undefined && (
                       <span className="text-foreground font-mono font-medium tabular-nums">
-                        {item.value.toLocaleString()}
+                        {typeof item.value === "number"
+                          ? item.value.toLocaleString()
+                          : String(item.value)}
                       </span>
                     )}
                   </div>
@@ -254,11 +263,12 @@ function ChartLegendContent({
   payload,
   verticalAlign = "bottom",
   nameKey,
-}: ComponentProps<"div"> &
-  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
-    hideIcon?: boolean
-    nameKey?: string
-  }) {
+}: ComponentProps<"div"> & {
+  payload?: TooltipPayloadEntry<ValueType, NameType>[]
+  verticalAlign?: "top" | "bottom" | "middle"
+  hideIcon?: boolean
+  nameKey?: string
+}) {
   const { config } = useChart()
 
   if (!payload?.length) {
@@ -273,13 +283,13 @@ function ChartLegendContent({
         className
       )}
     >
-      {payload.map((item) => {
+      {payload.map((item, index) => {
         const key = `${nameKey || item.dataKey || "value"}`
         const itemConfig = getPayloadConfigFromPayload(config, item, key)
 
         return (
           <div
-            key={item.value}
+            key={item.value?.toString() ?? index}
             className={cn(
               "[&>svg]:text-muted-foreground flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3"
             )}

--- a/src/components/ui/chart.tsx
+++ b/src/components/ui/chart.tsx
@@ -187,7 +187,7 @@ function ChartTooltipContent({
         {payload.map((item, index) => {
           const key = `${nameKey || item.name || item.dataKey || "value"}`
           const itemConfig = getPayloadConfigFromPayload(config, item, key)
-          const indicatorColor = color || (item.payload as any)?.fill || item.color
+          const indicatorColor = color || item.payload?.fill || item.color
 
           return (
             <div

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -2,7 +2,7 @@
 
 import { ComponentProps } from "react"
 import * as CheckboxPrimitive from "@radix-ui/react-checkbox"
-import CheckIcon from "lucide-react/dist/esm/icons/check"
+import { CheckIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -2,7 +2,7 @@
 
 import { ComponentProps } from "react"
 import { Command as CommandPrimitive } from "cmdk"
-import SearchIcon from "lucide-react/dist/esm/icons/search"
+import { SearchIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import {

--- a/src/components/ui/context-menu.tsx
+++ b/src/components/ui/context-menu.tsx
@@ -2,9 +2,7 @@
 
 import { ComponentProps } from "react"
 import * as ContextMenuPrimitive from "@radix-ui/react-context-menu"
-import CheckIcon from "lucide-react/dist/esm/icons/check";
-import ChevronRightIcon from "lucide-react/dist/esm/icons/chevron-right"
-import CircleIcon from "lucide-react/dist/esm/icons/circle"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps } from "react"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
-import XIcon from "lucide-react/dist/esm/icons/x"
+import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -2,9 +2,7 @@
 
 import { ComponentProps } from "react"
 import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu"
-import CheckIcon from "lucide-react/dist/esm/icons/check"
-import ChevronRightIcon from "lucide-react/dist/esm/icons/chevron-right"
-import CircleIcon from "lucide-react/dist/esm/icons/circle"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/input-otp.tsx
+++ b/src/components/ui/input-otp.tsx
@@ -2,7 +2,7 @@
 
 import { ComponentProps, useContext } from "react"
 import { OTPInput, OTPInputContext } from "input-otp"
-import MinusIcon from "lucide-react/dist/esm/icons/minus"
+import { MinusIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/menubar.tsx
+++ b/src/components/ui/menubar.tsx
@@ -1,8 +1,6 @@
 import { ComponentProps } from "react"
 import * as MenubarPrimitive from "@radix-ui/react-menubar"
-import CheckIcon from "lucide-react/dist/esm/icons/check"
-import ChevronRightIcon from "lucide-react/dist/esm/icons/chevron-right"
-import CircleIcon from "lucide-react/dist/esm/icons/circle"
+import { CheckIcon, ChevronRightIcon, CircleIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -1,7 +1,7 @@
 import { ComponentProps } from "react"
 import * as NavigationMenuPrimitive from "@radix-ui/react-navigation-menu"
 import { cva } from "class-variance-authority"
-import ChevronDownIcon from "lucide-react/dist/esm/icons/chevron-down"
+import { ChevronDownIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/pagination.tsx
+++ b/src/components/ui/pagination.tsx
@@ -1,7 +1,5 @@
 import { ComponentProps } from "react"
-import ChevronLeftIcon from "lucide-react/dist/esm/icons/chevron-left"
-import ChevronRightIcon from "lucide-react/dist/esm/icons/chevron-right"
-import MoreHorizontalIcon from "lucide-react/dist/esm/icons/more-horizontal"
+import { ChevronLeftIcon, ChevronRightIcon, MoreHorizontalIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 import { Button, buttonVariants } from "@/components/ui/button"

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -2,7 +2,7 @@
 
 import { ComponentProps } from "react"
 import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
-import CircleIcon from "lucide-react/dist/esm/icons/circle"
+import { CircleIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from "react"
-import GripVerticalIcon from "lucide-react/dist/esm/icons/grip-vertical"
+import { GripVerticalIcon } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
@@ -7,9 +7,9 @@ import { cn } from "@/lib/utils"
 function ResizablePanelGroup({
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: ComponentProps<typeof ResizablePrimitive.Group>) {
   return (
-    <ResizablePrimitive.PanelGroup
+    <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
       className={cn(
         "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
@@ -30,11 +30,11 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
@@ -47,7 +47,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   )
 }
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from "react"
-import { GripVerticalIcon } from "lucide-react"
+import GripVerticalIcon from "lucide-react/dist/esm/icons/grip-vertical"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
@@ -7,9 +7,9 @@ import { cn } from "@/lib/utils"
 function ResizablePanelGroup({
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.Group>) {
+}: ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
   return (
-    <ResizablePrimitive.Group
+    <ResizablePrimitive.PanelGroup
       data-slot="resizable-panel-group"
       className={cn(
         "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
@@ -30,11 +30,11 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.Separator> & {
+}: ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.Separator
+    <ResizablePrimitive.PanelResizeHandle
       data-slot="resizable-handle"
       className={cn(
         "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
@@ -47,7 +47,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.Separator>
+    </ResizablePrimitive.PanelResizeHandle>
   )
 }
 

--- a/src/components/ui/resizable.tsx
+++ b/src/components/ui/resizable.tsx
@@ -1,5 +1,5 @@
 import { ComponentProps } from "react"
-import GripVerticalIcon from "lucide-react/dist/esm/icons/grip-vertical"
+import { GripVerticalIcon } from "lucide-react"
 import * as ResizablePrimitive from "react-resizable-panels"
 
 import { cn } from "@/lib/utils"
@@ -7,14 +7,11 @@ import { cn } from "@/lib/utils"
 function ResizablePanelGroup({
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.PanelGroup>) {
+}: ComponentProps<typeof ResizablePrimitive.Group>) {
   return (
-    <ResizablePrimitive.PanelGroup
+    <ResizablePrimitive.Group
       data-slot="resizable-panel-group"
-      className={cn(
-        "flex h-full w-full data-[panel-group-direction=vertical]:flex-col",
-        className
-      )}
+      className={cn("flex h-full w-full", className)}
       {...props}
     />
   )
@@ -30,14 +27,14 @@ function ResizableHandle({
   withHandle,
   className,
   ...props
-}: ComponentProps<typeof ResizablePrimitive.PanelResizeHandle> & {
+}: ComponentProps<typeof ResizablePrimitive.Separator> & {
   withHandle?: boolean
 }) {
   return (
-    <ResizablePrimitive.PanelResizeHandle
+    <ResizablePrimitive.Separator
       data-slot="resizable-handle"
       className={cn(
-        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden data-[panel-group-direction=vertical]:h-px data-[panel-group-direction=vertical]:w-full data-[panel-group-direction=vertical]:after:left-0 data-[panel-group-direction=vertical]:after:h-1 data-[panel-group-direction=vertical]:after:w-full data-[panel-group-direction=vertical]:after:-translate-y-1/2 data-[panel-group-direction=vertical]:after:translate-x-0 [&[data-panel-group-direction=vertical]>div]:rotate-90",
+        "bg-border focus-visible:ring-ring relative flex w-px items-center justify-center after:absolute after:inset-y-0 after:left-1/2 after:w-1 after:-translate-x-1/2 focus-visible:ring-1 focus-visible:ring-offset-1 focus-visible:outline-hidden aria-[orientation=horizontal]:h-px aria-[orientation=horizontal]:w-full aria-[orientation=horizontal]:after:left-0 aria-[orientation=horizontal]:after:h-1 aria-[orientation=horizontal]:after:w-full aria-[orientation=horizontal]:after:-translate-y-1/2 aria-[orientation=horizontal]:after:translate-x-0 aria-[orientation=horizontal]:[&>div]:rotate-90",
         className
       )}
       {...props}
@@ -47,7 +44,7 @@ function ResizableHandle({
           <GripVerticalIcon className="size-2.5" />
         </div>
       )}
-    </ResizablePrimitive.PanelResizeHandle>
+    </ResizablePrimitive.Separator>
   )
 }
 

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -1,8 +1,6 @@
 import { ComponentProps } from "react"
 import * as SelectPrimitive from "@radix-ui/react-select"
-import CheckIcon from "lucide-react/dist/esm/icons/check"
-import ChevronDownIcon from "lucide-react/dist/esm/icons/chevron-down"
-import ChevronUpIcon from "lucide-react/dist/esm/icons/chevron-up"
+import { CheckIcon, ChevronDownIcon, ChevronUpIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -1,6 +1,6 @@
 import { ComponentProps } from "react"
 import * as SheetPrimitive from "@radix-ui/react-dialog"
-import XIcon from "lucide-react/dist/esm/icons/x"
+import { XIcon } from "lucide-react"
 
 import { cn } from "@/lib/utils"
 

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -3,7 +3,7 @@
 import { CSSProperties, ComponentProps, createContext, useCallback, useContext, useEffect, useMemo, useState } from "react"
 import { Slot } from "@radix-ui/react-slot"
 import { VariantProps, cva } from "class-variance-authority"
-import PanelLeftIcon from "lucide-react/dist/esm/icons/panel-left"
+import { PanelLeftIcon } from "lucide-react"
 
 import { useIsMobile } from "@/hooks/use-mobile"
 import { cn } from "@/lib/utils"

--- a/src/lib/userStats.ts
+++ b/src/lib/userStats.ts
@@ -1,0 +1,44 @@
+import { APIService } from '@/lib/api'
+
+export type UserStats = {
+  productsSubmitted: number
+  collectionsCreated: number
+  productsOwnedSubmitted: number
+  productsEditedManaged: number
+  collectionsOwnedSubmitted: number
+  collectionsEditedManaged: number
+  ratingsGiven: number
+  discussionsParticipated: number
+  totalContributions: number
+}
+
+export const EMPTY_USER_STATS: UserStats = {
+  productsSubmitted: 0,
+  collectionsCreated: 0,
+  productsOwnedSubmitted: 0,
+  productsEditedManaged: 0,
+  collectionsOwnedSubmitted: 0,
+  collectionsEditedManaged: 0,
+  ratingsGiven: 0,
+  discussionsParticipated: 0,
+  totalContributions: 0,
+}
+
+function normalizeUserStats(raw: Partial<UserStats>): UserStats {
+  return {
+    productsSubmitted: raw.productsSubmitted ?? 0,
+    collectionsCreated: raw.collectionsCreated ?? 0,
+    productsOwnedSubmitted: raw.productsOwnedSubmitted ?? 0,
+    productsEditedManaged: raw.productsEditedManaged ?? 0,
+    collectionsOwnedSubmitted: raw.collectionsOwnedSubmitted ?? 0,
+    collectionsEditedManaged: raw.collectionsEditedManaged ?? 0,
+    ratingsGiven: raw.ratingsGiven ?? 0,
+    discussionsParticipated: raw.discussionsParticipated ?? 0,
+    totalContributions: raw.totalContributions ?? 0,
+  }
+}
+
+export async function fetchUserStats(userRef: string): Promise<UserStats> {
+  const raw = await APIService.getUserStats(userRef)
+  return normalizeUserStats(raw)
+}


### PR DESCRIPTION
## Summary

Finished up all the Typescript errors (from issue #508), **currently no errors** should be present when running `npx tsc.` Specifically (wordings taken exactly from issue):
- [x] src/components/UserProfile.tsx (3 errors: lines 66, 67, 156) — Lines 66/67: userAccount.username is string | undefined but used as string; stats object from API has optional fields but state is typed with required fields — the state initializer and API response type diverged. Line 156: userAccount.username possibly undefined.
- [x] src/components/PublicProfile.tsx (1 error: line 44) — Same stats optional-vs-required mismatch as UserProfile.tsx — fixed both together.
- [x] src/components/AboutPage.tsx (1 error: line 22) — string | Promise<string> passed where string | Node is expected — an async function result (marked.parse()) used synchronously in a DOM context; fixed by awaiting the result.
- [x] src/components/RavelrySettings.tsx (3 errors: lines 540, 592, 596) — Line 540: No overload matches call — investigated and resolved with a fallback for missing timestamps. Lines 592/596: Property 'data' does not exist on type 'SaveLog' — SaveLog type had diverged from what the component expected; added the missing data field to the type.
- [x] src/__tests__/accessibility/ProductSubmission.a11y.test.tsx:26,27 — null not assignable to Product | undefined; changed null to undefined.
- [x] src/__tests__/accessibility/ProfileEdit.a11y.test.tsx:218 — No overload matches call; investigated the component's props and resolved with a non-null assertion on a guaranteed test fixture value.
- [x]  src/components/ui/chart.tsx (5 errors: lines 107, 112, 258, 264, 276) — Recharts type definitions didn't match the installed version (payload, label, length, map properties missing from inferred types). Fixed by updating the component's type imports/annotations to match Recharts v3's actual exported types (TooltipContentProps, TooltipPayloadEntry) rather than the outdated v2-style types the component was written against.
- [x] src/components/ui/resizable.tsx (5 errors: lines 10, 12, 33, 37, 50) — Not in the original list; surfaced during cleanup. react-resizable-panels didn't export PanelGroup/PanelResizeHandle the way the code expected due to a library version mismatch. Fixed by updating references to the library's current export names (Group, Separator) at the installed version.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor
- [ ] Documentation update
- [x] Test update
- [ ] CI/workflow update

## Validation

- [ ] Tests added or updated where relevant
- [x] Local tests run for changed behavior
- [x] Lint passes

## Notes for Reviewers

The most complicated changes were made in `chart.tsx` and `resizable.tsx`, where I looked at what the installed library actually exports and updated the code to use the correct names. Again, all tests pass when running `npm test` but I do want to confirm this looks correct.