### PR TITLE
Center last updated date input

### DIFF
--- a/src/__tests__/components/ProductFilters.test.tsx
+++ b/src/__tests__/components/ProductFilters.test.tsx
@@ -81,6 +81,12 @@ describe('ProductFilters', () => {
     expect(screen.getByText(/minimum rating/i)).toBeInTheDocument()
   })
 
+  it('should center the last updated date', () => {
+    render(<ProductFilters {...mockProps} />)
+
+    expect(screen.getByLabelText('Filter by last update date')).toHaveClass('text-center')
+  })
+
   it('should display selected tags with different styling', () => {
     const propsWithSelectedTags = {
       ...mockProps,

--- a/src/components/ProductFilters.tsx
+++ b/src/components/ProductFilters.tsx
@@ -161,7 +161,7 @@ export function ProductFilters({
             type="date"
             value={updatedSince || ''}
             onChange={(e) => onUpdatedSinceChange(e.target.value || null)}
-            className="text-sm flex-1"
+            className="text-sm text-center flex-1"
             aria-label="Filter by last update date"
           />
         </div>


### PR DESCRIPTION
## Summary

Centers the date placeholder and value in the Last updated since filter.

Closes #518.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation update
- [x] Test update
- [ ] CI/workflow update

## Validation

- [x] Tests added or updated where relevant
- [x] Local tests run for changed behavior
- [x] Lint passes

Validation run:
- 182 passed, 1 skipped in the reduced test suite
- ProductFilters component and axe accessibility tests
- TypeScript check and production build
- Chrome visual check

The linter reports one existing warning in CollectionDetail.tsx and no errors.

## Accessibility Checklist

- [x] Keyboard navigation works end-to-end
- [x] Focus states are visible and focus order is logical
- [x] Forms have associated labels and errors are announced
- [x] Color is not the only indicator for state or meaning
- [x] Reduced motion is respected (if animations were added)
- [x] Screen reader behavior was checked at least once

## Screenshots or Recordings (If UI Changed)

The before state is shown in #518. The centered placeholder and value were checked in Chrome.

## Notes for Reviewers

The change only adds text alignment to the existing date input.